### PR TITLE
allow legacy deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "postinstall": "npm run client:build",
     "client:dev": "react-scripts start",
-    "client:build": "react-scripts build",
+    "client:build": "react-scripts --openssl-legacy-provider build",
     "server:dev": "nodemon index.js",
     "db:build": "node ./db/init_db",
     "start": "node index.js"


### PR DESCRIPTION
According to [this article](https://www.freecodecamp.org/news/error-error-0308010c-digital-envelope-routines-unsupported-node-error-solved/), running react-scripts with the --openssl-legacy-provider flag will fix the errors in the Heroku logs, from the `client:build` script:
```
       > starting_code@1.0.0 client:build
       > react-scripts build
       
       Creating an optimized production build...
       Error: error:0308010C:digital envelope routines::unsupported
```

The other option which I think will work: Upgrade react-scripts
```
npm uninstall react-scripts
npm i react-scripts
```